### PR TITLE
Clear previous timeout before each render

### DIFF
--- a/src/components/Countdown/index.js
+++ b/src/components/Countdown/index.js
@@ -11,12 +11,13 @@ export default function Countdown() {
       if (counter <= 0) {
         return;
       }
-      setTimeout(
+      const timeoutId = setTimeout(
         () => setCounter(
           (n) => n - 1
         ),
         500
       );
+      return () => clearTimeout(timeoutId);
     },
     [counter]
   );


### PR DESCRIPTION
If we do not clear the previous timeout before each render, we end up
with multiple timeout loops running decrementing our counter (which
leads to the rate of decrement being too fast).

Resolves #5