### PR TITLE
Clear previous timeout before each render

### DIFF
--- a/src/components/Countdown/index.js
+++ b/src/components/Countdown/index.js
@@ -11,12 +11,13 @@ export default function Countdown() {
       if (counter <= 0) {
         return;
       }
-      setTimeout(
+      const timeoutId = setTimeout(
         () => setCounter(
           (n) => n - 1
         ),
         500
       );
+      return () => clearTimeout(timeoutId);
     },
     [counter]
   );


### PR DESCRIPTION
When a reset was performed, we saw two timeouts running simultaneously

By clearing the timeout in the cleanup, we prevent this.

Resolves #5